### PR TITLE
Url main

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -86,7 +86,7 @@ imio_push = git@github.com:IMIO
 setuptools = 33.1.1
 zc.buildout = 2.9.5
 collective.printrss =
-pycodestyle = 2.3.1
+# pycodestyle = 2.3.1
 
 Pygments = 2.0.2
 plone.app.robotframework = 1.1

--- a/src/collective/printrss/interfaces.py
+++ b/src/collective/printrss/interfaces.py
@@ -36,6 +36,12 @@ class IRssFeed(Interface):
         required=True,
         default=u'')
 
+    url_main = schema.TextLine(
+        title=_(u'URL of main page of external site'),
+        description=_(u'If this field is completed, in index view, the title link of the rss feed will redirect to this url if not, you will be redirected to the homepage of the rss link site.'),
+        required=False,
+        default=u'')
+
     timeout = schema.Int(
         title=_(u'Feed reload timeout'),
         description=_(u'Time in minutes after which the feed should be '

--- a/src/collective/printrss/locales/collective.printrss.pot
+++ b/src/collective/printrss/locales/collective.printrss.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-03 14:29+0000\n"
+"POT-Creation-Date: 2019-02-04 13:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: ../interfaces.py:40
+#: ../interfaces.py:46
 msgid "Feed reload timeout"
 msgstr ""
 
@@ -29,11 +29,19 @@ msgstr ""
 msgid "How many items to list."
 msgstr ""
 
+#: ../interfaces.py:41
+msgid "If this field is completed, in index view, the title link of the rss feed will redirect to this url if not, you will be redirected to the homepage of the rss link site."
+msgstr ""
+
+#: ../configure.zcml:21
+msgid "Installs the collective.printrss add-on."
+msgstr ""
+
 #: ../interfaces.py:35
 msgid "Link of the RSS feed to display."
 msgstr ""
 
-#: ../interfaces.py:49
+#: ../interfaces.py:55
 msgid "Number of items must be <= 20!"
 msgstr ""
 
@@ -41,7 +49,7 @@ msgstr ""
 msgid "Number of items to display"
 msgstr ""
 
-#: ../interfaces.py:41
+#: ../interfaces.py:47
 msgid "Time in minutes after which the feed should be reloaded."
 msgstr ""
 
@@ -53,7 +61,14 @@ msgstr ""
 msgid "URL of RSS feed"
 msgstr ""
 
+#: ../interfaces.py:40
+msgid "URL of main page of external site"
+msgstr ""
+
+#: ../configure.zcml:21
+msgid "collective.printrss"
+msgstr ""
+
 #: ../profiles/default/types/rss_feed.xml
 msgid "rss_feed"
 msgstr ""
-

--- a/src/collective/printrss/locales/en/LC_MESSAGES/collective.printrss.po
+++ b/src/collective/printrss/locales/en/LC_MESSAGES/collective.printrss.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-03 14:29+0000\n"
+"POT-Creation-Date: 2019-02-04 12:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: ../interfaces.py:40
+#: ../interfaces.py:46
 msgid "Feed reload timeout"
 msgstr ""
 
@@ -26,11 +26,19 @@ msgstr ""
 msgid "How many items to list."
 msgstr ""
 
+#: ../interfaces.py:41
+msgid "If this field is completed, in index view, the title link of the rss feed will redirect to this url if not, you will be redirected to the homepage of the rss link site."
+msgstr ""
+
+#: ../configure.zcml:21
+msgid "Installs the collective.printrss add-on."
+msgstr ""
+
 #: ../interfaces.py:35
 msgid "Link of the RSS feed to display."
 msgstr ""
 
-#: ../interfaces.py:49
+#: ../interfaces.py:55
 msgid "Number of items must be <= 20!"
 msgstr ""
 
@@ -38,7 +46,7 @@ msgstr ""
 msgid "Number of items to display"
 msgstr ""
 
-#: ../interfaces.py:41
+#: ../interfaces.py:47
 msgid "Time in minutes after which the feed should be reloaded."
 msgstr ""
 
@@ -50,7 +58,14 @@ msgstr ""
 msgid "URL of RSS feed"
 msgstr ""
 
+#: ../interfaces.py:40
+msgid "URL of main page of external site"
+msgstr ""
+
+#: ../configure.zcml:21
+msgid "collective.printrss"
+msgstr ""
+
 #: ../profiles/default/types/rss_feed.xml
 msgid "rss_feed"
 msgstr ""
-

--- a/src/collective/printrss/locales/fr/LC_MESSAGES/collective.printrss.po
+++ b/src/collective/printrss/locales/fr/LC_MESSAGES/collective.printrss.po
@@ -59,7 +59,7 @@ msgid "URL of RSS feed"
 msgstr "Lien vers le flux RSS"
 
 #: ../interfaces.py:40
-msgid "URL of main page of external site."
+msgid "URL of main page of external site"
 msgstr "Lien vers la page principale du site hébergeant le flux RSS."
 
 #: ../configure.zcml:21

--- a/src/collective/printrss/locales/fr/LC_MESSAGES/collective.printrss.po
+++ b/src/collective/printrss/locales/fr/LC_MESSAGES/collective.printrss.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-03 14:29+0000\n"
+"POT-Creation-Date: 2019-02-04 12:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 msgid "Description"
 msgstr "Description"
 
-#: ../interfaces.py:40
+#: ../interfaces.py:46
 msgid "Feed reload timeout"
 msgstr "Temps qui doit s'écouler avant le rechargement du flux (en minutes)"
 
@@ -26,11 +26,19 @@ msgstr "Temps qui doit s'écouler avant le rechargement du flux (en minutes)"
 msgid "How many items to list."
 msgstr "Nombre de résultat à afficher"
 
+#: ../interfaces.py:41
+msgid "If this field is completed, in index view, the title link of the rss feed will redirect to this url if not, you will be redirected to the homepage of the rss link site."
+msgstr "Si ce champs est complété, en vue index, le lien du titre du flux rss redirigiera vers cett url sinon, vous serez redirigé vers la page d'accueil du site du lien rss."
+
+#: ../configure.zcml:21
+msgid "Installs the collective.printrss add-on."
+msgstr "Installer le module collective.printrss"
+
 #: ../interfaces.py:35
 msgid "Link of the RSS feed to display."
 msgstr "Lien du flux RSS à afficher"
 
-#: ../interfaces.py:49
+#: ../interfaces.py:55
 msgid "Number of items must be <= 20!"
 msgstr "Le nombre de résultat à afficher doit être <= 20"
 
@@ -38,7 +46,7 @@ msgstr "Le nombre de résultat à afficher doit être <= 20"
 msgid "Number of items to display"
 msgstr "Nombre de résultat à afficher"
 
-#: ../interfaces.py:41
+#: ../interfaces.py:47
 msgid "Time in minutes after which the feed should be reloaded."
 msgstr "Temps (en minutes) pour le rechargement du flux."
 
@@ -50,7 +58,14 @@ msgstr "Titre"
 msgid "URL of RSS feed"
 msgstr "Lien vers le flux RSS"
 
+#: ../interfaces.py:40
+msgid "URL of main page of external site."
+msgstr "Lien vers la page principale du site hébergeant le flux RSS."
+
+#: ../configure.zcml:21
+msgid "collective.printrss"
+msgstr ""
+
 #: ../profiles/default/types/rss_feed.xml
 msgid "rss_feed"
 msgstr ""
-


### PR DESCRIPTION
Add new field to get main url of external website where rss field is. 
sample : 
if feed is located at : 
https://blog.ubuntu.com/feed

I can specify the "main" url : 
https://blog.ubuntu.com 

and in view index "view-all link" and "title link" use this new url.